### PR TITLE
Added --without-zlib to configure path to fix the linkage error

### DIFF
--- a/build_libcurl_dist.sh
+++ b/build_libcurl_dist.sh
@@ -20,7 +20,7 @@ function build_for_arch() {
   export PATH="${DEVROOT}/usr/bin/:${PATH}"
   export CFLAGS="-arch ${ARCH} -pipe -Os -gdwarf-2 -isysroot ${SYSROOT} -miphoneos-version-min=${IPHONEOS_DEPLOYMENT_TARGET} -fembed-bitcode"
   export LDFLAGS="-arch ${ARCH} -isysroot ${SYSROOT}"
-  ./configure --disable-shared --enable-static --enable-ipv6 ${SSL_FLAG} --host="${HOST}" --prefix=${PREFIX} && make -j8 && make install
+  ./configure --disable-shared --without-zlib --enable-static --enable-ipv6 ${SSL_FLAG} --host="${HOST}" --prefix=${PREFIX} && make -j8 && make install
 }
 
 if [ "$1" == "openssl" ]


### PR DESCRIPTION
To fix the linkage error

Undefined symbols for architecture arm64:
"_inflate", referenced from:
_inflate_stream in libcurl.a(libcurl_la-content_encoding.o)
"_inflateEnd", referenced from:
_inflate_stream in libcurl.a(libcurl_la-content_encoding.o)