### PR TITLE
use secure transport ssl flag instead of darwin ssl

### DIFF
--- a/build_libcurl_dist.sh
+++ b/build_libcurl_dist.sh
@@ -35,7 +35,7 @@ then
   export SSL_FLAG=--with-ssl=${HOME}/Desktop/openssl-ios-dist
 else
   check_curl_ver
-  export SSL_FLAG=--with-darwinssl
+  export SSL_FLAG=--with-secure-transport
 fi
 
 TMP_DIR=/tmp/build_libcurl_$$


### PR DESCRIPTION
Looks like `--with-darwinssl` has been deprecated, we can use `--with-secure-transport` SSL flag instead.